### PR TITLE
code changes to resolve upload image with same title

### DIFF
--- a/src/main/java/ImageHoster/controller/ImageController.java
+++ b/src/main/java/ImageHoster/controller/ImageController.java
@@ -45,9 +45,10 @@ public class ImageController {
     //Also now you need to add the tags of an image in the Model type object
     //Here a list of tags is added in the Model type object
     //this list is then sent to 'images/image.html' file and the tags are displayed
-    @RequestMapping("/images/{title}")
-    public String showImage(@PathVariable("title") String title, Model model) {
-        Image image = imageService.getImageByTitle(title);
+    @RequestMapping("/images/{imageId}/{title}")
+    public String showImage(@PathVariable("title") String title,@PathVariable("imageId") Integer id, Model model) {
+       // Image image = imageService.getImageByTitle(title);
+        Image image = imageService.getImage(id);
         model.addAttribute("image", image);
         model.addAttribute("tags", image.getTags());
         return "images/image";

--- a/src/main/resources/templates/images.html
+++ b/src/main/resources/templates/images.html
@@ -18,7 +18,7 @@
         </div>
 
         <!--Change <a th:href="'/images/' + ${i.title}"> to <a th:href="'/images/' +${i.id} +'/' +${i.title}">-->
-        <a th:href="'/images/' + ${i.title}">
+        <a th:href="'/images/'+${i.id}+'/'+ ${i.title}">
             <h3 th:text="${i.title}">Title of image</h3>
         </a>
         <i>Posted On: </i> <span th:text="${i.date}"></span>


### PR DESCRIPTION
On uploading an image with the same exact title as of a previously uploaded image, it will get uploaded. But then, on navigating to one of the images with the same title, the image uploader will display an error.
Included the image_id in path parameter and passed image_id to fetch image from DB so that, single result is fetched from DB